### PR TITLE
Performance improvement

### DIFF
--- a/js/bootstrap-tree.js
+++ b/js/bootstrap-tree.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
 	$('.tree > ul').attr('role', 'tree').find('ul').attr('role', 'group');
 	$('.tree').find('li:has(ul)').addClass('parent_li').attr('role', 'treeitem').find(' > span').attr('title', 'Collapse this branch').on('click', function (e) {
-        var children = $(this).parent('li.parent_li').find(' > ul > li');
+        var children = $(this).parent('li.parent_li').find(' > ul');
         if (children.is(':visible')) {
     		children.hide('fast');
     		$(this).attr('title', 'Expand this branch').find(' > i').addClass('icon-plus-sign').removeClass('icon-minus-sign');


### PR DESCRIPTION
If there are a lot of 'li', it's getting really slow to open/close a
tree node, because all 'li's are changed. Just changing the visibility
of the whole 'ul' instead greatly improves performances
